### PR TITLE
Uniform API

### DIFF
--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -565,12 +565,12 @@ used.
 
 Each instantiation of this framework thus corresponds to one of four variants:
 
-| PQ C2PRI? | T component   |    | Structure      | Combiner   |
-|:==========|:==============|====|:===============|:===========|
-| No        | Nominal group | => | {{group-inst}} | Explicit   |
-| No        | KEM           | => | {{kem-inst}}   | Explicit   |
-| Yes       | Nominal group | => | {{group-inst}} | PQImplicit |
-| Yes       | KEM           | => | {{kem-inst}}   | PQImplicit |
+| Name    | PQ C2PRI? | T component   |    | Structure      | Combiner   |
+|:========|:==========|:==============|====|:===============|:===========|
+| GX      | No        | Nominal group | => | {{group-inst}} | Explicit   |
+| KX      | No        | KEM           | => | {{kem-inst}}   | Explicit   |
+| GM      | Yes       | Nominal group | => | {{group-inst}} | PQImplicit |
+| KM      | Yes       | KEM           | => | {{kem-inst}}   | PQImplicit |
 {: #variants title="Variants of the hybrid KEM framework" }
 
 ## Combiner Functions


### PR DESCRIPTION
It has become clear in CFRG discussions that the limitation of GHP to only KEM+KEM and QSF to only KEM+Group is insufficient.  Folks want to instantiate QSF with RSA (see, e.g., [LAMPS](https://www.ietf.org/archive/id/draft-ietf-lamps-pq-composite-kem-07.html)), and folks being conservative about C2PRI want to instantiate GHP with ECDH groups in the T component.

We thus end up with four combinations to consider:
1. PQ(IND-CCA + C2PRI) + T(Group) = QSF
2. PQ(IND-CCA + C2PRI) + T(KEM)
3. PQ(IND-CCA only) + T(Group)
4. PQ(IND-CCA only) + T(KEM) = GHP

This PR attempts to present these options in a unified framework, with two binary choices: KEM vs. group, and C2PRI or not.  This PR does not make the corresponding changes to the Security Considerations, which will need to be updated to match if we adopt this approach.

The framework here could be simpler if we defined a DH-based thing that satisfied the KEM interface.  This would be problematic, however, because the resulting "KEM" would not be IND-CCA.  Given this fact, and the fact that defining such a "KEM" would take up about the same amount of space as the repetition we currently have, I think the current approach of keeping these separate is the right one.