### PR TITLE
Name individual frameworks, but call out subroutines

### DIFF
--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -582,7 +582,7 @@ components:
   components being used, as well as which framework is being instantiated.
   This value should be registered in the Hybrid KEM
   Labels IANA registry to avoid conflict with other instantiations (see
-  {{iana-considerations}}.
+  {{iana-considerations}}).
 
 `KEM_PQ`, `Group_T`, `PRG`, and `KDF` MUST meet the interfaces
 described in {{cryptographic-deps}} and MUST meet the security requirements


### PR DESCRIPTION
This PR attempts a middle ground between #72 and #79, reflecting a few points of feedback from the 2026-09-25 CFRG interim:

* Having names and section titles for specific frameworks helps implementors zero in on the right parts
* But we should also minimize duplication across these sections

To do this, I made a section for each specific framework (using the "two letter" naming scheme), but having a section full of subroutines to capture the common structure.

This PR also:

* Replaces #73 by addressing key generation and its variations.  
* Adds a note about C2PRI to the introduction, reflecting mailing list feedback that an earlier mention was needed