### PR TITLE
Use PRGs instead of seeds

### DIFF
--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -409,7 +409,7 @@ trivial PRG that simply reads from those bytes:
 - `New(seed)` - Initialize `state` with a copy of `seed`
 - `Read(state, n)` - If there are fewer than `n` bytes in `state`, abort. Split
   off the first `n` bytes of `state` and return them as `out`, and update
-  `state` to remove the first `n` bytes.  
+  `state` to remove the first `n` bytes.
 
 ## Key Encapsulation Mechanisms {#kems}
 


### PR DESCRIPTION
This PR replaces seeds with PRGs as inputs to randomized algorithms.  For the most part, this is just saying the same thing: Either you pass a seed full of bytes you just drew from a PRG or you hand the PRG and let the seed reading be done interior to the function.

The PRG approach has the advantage that if the entropy demands of the function are not known up front, then the function can read a variable amount from the PRG.  The case in point for this is [rejection sampling for NIST curve keygen](https://github.com/cfrg/draft-irtf-cfrg-concrete-hybrid-kems/pull/30#pullrequestreview-3353961597).  This approach thus solves some issues at the [concrete hybrid KEM](https://github.com/hpkewg/hpke-pq/issues/30) and [HPKE](https://github.com/cfrg/draft-irtf-cfrg-concrete-hybrid-kems/issues/22) levels.

The PRG also makes it easier to discuss derandomized versions of key generation and encapsulation.  You just define a trivial PRG that reads an existing string of random bytes.  This is the mirror image of what FIPS 203 does with KeyGen/Encaps vs. KeyGen_Internal/Encaps_Internal, choosing the PRG as the primary interface because some things need variable randomness.