### PR TITLE
Fix security text: deduplicate non-goals, proof corrections, spec clarity

### DIFF
--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -1474,7 +1474,15 @@ post-quantum and a traditional KEM.
 ## Parameterized Output Length
 
 Not analyzed as part of any security proofs in the literature, and a
-complication deemed unnecessary.
+Security properties and design considerations that were considered
+and not included in these designs:
+
+- Anonymity {{GMP22}}, Deniability, Obfuscation, other forms of key-robustness
+or binding {{GMP22}}, {{CDM23}}
+
+- More than two components: this document restricts the scope to two components: a post-quantum component and a traditional component.
+
+- Parameterized output length: not analyzed as part of any security proofs in the literature, and a complication deemed unnecessary.
 
 --- back
 


### PR DESCRIPTION
## Summary

This PR fixes editorial issues in the Security Considerations and Out of Scope sections, corrects proof text errors, and adds two clarifying statements about KEM semantics.

### Commit 1: Deduplicate non-goals text, fix Out of Scope prose

The Security Non-goals section (Section 8.3) duplicated the list from the Out of Scope section. Replace the duplicate with a cross-reference using a new `{#out-of-scope}` anchor. Also fix the Out of Scope section:
- "Considerations that were considered" -> clearer phrasing
- Add missing period after `{{CDM23}}`
- "Design team decided to restrict" -> "This document restricts"

### Commit 2: Fix proof text: grammar, missing parens, UK IND-CCA qualifier

- **HKDF indifferentiability**: Rewrote the HMAC-SHA-256 bullet to remove the incorrect prefix-free qualifier (which applies to plain Merkle-Damgard, not HMAC) and cite DRS+13 precisely: HMAC-SHA-256 is indifferentiable from a RO when the compression function underlying SHA-256 is modeled as a RO
- **Missing closing paren**: In both the CG and CK LEAK-BIND-K-CT proofs, `ss_PQ^1 (:= KEM_PQ.Decaps(dk_PQ^1, ct_PQ^1),` was missing the outer `)` that closes the `:=` group. The matching `ss_PQ^0` expression has `))`.
- **UK qualifier**: "does not have an IND-CCA analysis" -> "does not have a dedicated IND-CCA analysis". The next sentence explains that GHP18's proof adapts with trivial modifications.

### Commit 3: Add implicit rejection note, LEAK-BIND requirement for CG/CK binding

- **Implicit rejection**: Add a note after the Decaps API definition clarifying that Decaps is *modeled* as always returning a shared secret (not a universal API claim). Component KEMs with implicit rejection (e.g., ML-KEM) produce a deterministic pseudorandom output on invalid ciphertexts.
- **LEAK-BIND requirement**: State that the CG and CK binding analyses additionally require the corresponding LEAK-BIND property of `KEM_PQ`. This matches the language already used in the CG Binding section introduction and makes the precondition visible at the top of the binding analyses section.

### Commit 4: Fix HKDF indifferentiability claim, tighten Decaps modeling note

- **HKDF rewrite**: Remove incorrect prefix-free qualifier from HMAC-SHA-256 indifferentiability claim. DRS+13's result requires only that the compression function is modeled as a RO; prefix-free applies to plain Merkle-Damgard, not HMAC.
- **Decaps note**: "Note that Decaps always returns" -> "In this document, Decaps is modeled as always returning" to avoid implying a universal API constraint.
- **Binding language**: "new results by the editorial team" -> "results by the editorial team"
- **Line wrapping**: Rewrap affected lines to 72 chars.
